### PR TITLE
Added ngStyle and ngModel without ngmodule.ts file

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,2 @@
 <p>Welcome to Angular by Aakash</p>
-<app-user></app-user>
+<app-style-binding></app-style-binding>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,13 +9,15 @@ import { ClassBindingComponent } from "./class-binding/class-binding.component";
 import { NgClassDirComponent } from "./ng-class-dir/ng-class-dir.component";
 import { StyleBindingComponent } from "./style-binding/style-binding.component";
 import { TemplateReferenceComponent } from "./template-reference/template-reference.component";
+import { TwoWayBindingComponent } from "./two-way-binding/two-way-binding.component";
+import { FormsModule } from '@angular/forms';
 
 @Component({
     selector: 'app-root',
     standalone: true,
     templateUrl: './app.component.html',
     styleUrl: './app.component.css',
-    imports: [RouterOutlet, UserComponent, InlineComponent, InterpolationComponent, EventsComponent, BindingsComponent, ClassBindingComponent, NgClassDirComponent, StyleBindingComponent, TemplateReferenceComponent]
+    imports: [RouterOutlet, UserComponent, InlineComponent, InterpolationComponent, EventsComponent, BindingsComponent, ClassBindingComponent, NgClassDirComponent, StyleBindingComponent, TemplateReferenceComponent, TwoWayBindingComponent, FormsModule]
 })
 export class AppComponent {
   title = 'Learning Never Ends';

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { FormsModule } from '@angular/forms';
 
 import { routes } from './app.routes';
 

--- a/src/app/style-binding/style-binding.component.html
+++ b/src/app/style-binding/style-binding.component.html
@@ -10,7 +10,7 @@
  [style.fontSize.px]="'60'"
 [style.color]="'orange'" 
 [style.fontStyle]="'italic '">I am Aakash</h2> -->
-<h2 [style.color]="5>2 ? 'red' : ''">I am Aakash</h2>
+<!-- <h2 [style.color]="5>2 ? 'red' : ''">I am Aakash</h2> -->
 
-<!-- Below code does not work for ngStyle -->
-<!-- <h2 [ngStyle]="myStyles">I am Aakash</h2> -->
+Below code didn't work for ngStyle, but It is working now.
+<h2 [ngStyle]="myStyles">I am Aakash</h2>

--- a/src/app/style-binding/style-binding.component.ts
+++ b/src/app/style-binding/style-binding.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
-
+import { NgStyle } from '@angular/common';
 @Component({
   selector: 'app-style-binding',
   standalone: true,
-  imports: [],
+  imports: [NgStyle],
   templateUrl: './style-binding.component.html',
   styleUrl: './style-binding.component.css'
 })

--- a/src/app/two-way-binding/two-way-binding.component.html
+++ b/src/app/two-way-binding/two-way-binding.component.html
@@ -1,0 +1,2 @@
+<input [(ngModel)]="name" type="text">
+<h2>{{ name }}</h2>

--- a/src/app/two-way-binding/two-way-binding.component.spec.ts
+++ b/src/app/two-way-binding/two-way-binding.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TwoWayBindingComponent } from './two-way-binding.component';
+
+describe('TwoWayBindingComponent', () => {
+  let component: TwoWayBindingComponent;
+  let fixture: ComponentFixture<TwoWayBindingComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TwoWayBindingComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(TwoWayBindingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/two-way-binding/two-way-binding.component.ts
+++ b/src/app/two-way-binding/two-way-binding.component.ts
@@ -1,0 +1,15 @@
+import { Component, NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-two-way-binding',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './two-way-binding.component.html',
+  styleUrl: './two-way-binding.component.css'
+})
+
+export class TwoWayBindingComponent {
+
+  public name ='Aakash';
+}


### PR DESCRIPTION
- Added in.ts file :
 import { FormsModule } from '@angular/forms'; 
@Component({
  selector: 'app-two-way-binding',
  standalone: true,
  imports: [FormsModule]

-Then got access to use ngStyle and ngModel in the HTML template without any error:
<input [(ngModel)]="name" type="text">
<h2 [ngStyle]="myStyles">I am Aakash</h2>